### PR TITLE
fix: enable git push/pull operations inside container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,5 +30,27 @@ if [ ! -f /home/pi/.pi/agent/settings.json ]; then
     cp /opt/pi-staging/settings.json /home/pi/.pi/agent/settings.json
 fi
 
+# ── Git / GitHub setup ────────────────────────────────────────────
+# Configure gh as git's credential helper so that git push/pull through
+# the gateway proxy works without interactive prompts.  The agent's
+# dummy GH_TOKEN is sent through the proxy; the gateway replaces it
+# with the real token before it reaches GitHub.
+gosu pi gh auth setup-git 2>/dev/null || true
+gosu pi git config --global push.autoSetupRemote true
+
+# Auto-configure git identity from GitHub profile (via gateway proxy).
+# Only if not already set — preserves manual overrides.
+if ! gosu pi git config --global user.name &>/dev/null; then
+    GH_USER_JSON=$(gosu pi curl -sf https://api.github.com/user 2>/dev/null || true)
+    if [ -n "$GH_USER_JSON" ]; then
+        GH_NAME=$(echo "$GH_USER_JSON" | jq -r '.name // .login')
+        GH_ID=$(echo "$GH_USER_JSON" | jq -r '.id')
+        GH_LOGIN=$(echo "$GH_USER_JSON" | jq -r '.login')
+        gosu pi git config --global user.name "$GH_NAME"
+        gosu pi git config --global user.email "${GH_ID}+${GH_LOGIN}@users.noreply.github.com"
+        echo "Git identity: $GH_NAME <${GH_ID}+${GH_LOGIN}@users.noreply.github.com>"
+    fi
+fi
+
 # ── Drop to non-root user ────────────────────────────────────────
 exec gosu pi "$@"

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -14,6 +14,7 @@ See docs/plan-phase-2.md for full design.
 from __future__ import annotations
 
 import asyncio
+import base64
 import datetime
 import json as json_mod
 import logging
@@ -175,7 +176,7 @@ INTERCEPT_RULES: dict[str, dict] = {
     "github.com": {
         "strip_headers": ["authorization"],
         "inject_headers": {
-            "Authorization": "token {GH_TOKEN}",
+            "Authorization": "basic {GH_TOKEN}",
         },
     },
 }
@@ -212,7 +213,13 @@ def resolve_rules() -> dict[str, dict]:
 
             value = os.environ.get(var)
             if value:
-                inject[header] = template.replace(f"{{{var}}}", value)
+                # "basic {VAR}" → HTTP Basic auth (x-access-token:<token>)
+                # Used for github.com git smart-HTTP which requires Basic auth
+                if template.startswith("basic "):
+                    creds = base64.b64encode(f"x-access-token:{value}".encode()).decode()
+                    inject[header] = f"Basic {creds}"
+                else:
+                    inject[header] = template.replace(f"{{{var}}}", value)
                 log.info("  %s: %s → will inject %s", host, var, header)
             else:
                 log.info("  %s: %s not set, skipping %s", host, var, header)


### PR DESCRIPTION
## Summary

This PR fixes git authentication failures inside the agent container that prevented git push/pull operations.

## Changes

### Fetching gateway CA certificate...
- Added  to configure credential helper  
- Added  for automatic upstream tracking
- Auto-configure git identity from GitHub user profile via API

###  
- Changed  auth from  to  format
- Added base64 encoding for proper HTTP Basic auth: 

## Root Causes Fixed

1. **No git credential helper** → Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  licenses:      View third-party license information
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` now handles auth prompts
2. **Wrong auth header format** → GitHub git smart-HTTP now gets proper Basic auth  
3. **Missing git identity** → Auto-configured from GitHub profile

## Testing

Verified full git workflow works inside container:
- 052db54c80a71e8e596a46f701c624abc94c1ea1	HEAD
052db54c80a71e8e596a46f701c624abc94c1ea1	refs/heads/feat/enhance-readme
780066cb95948f6735cd6bc5fbb083ec83193968	refs/heads/fix/git-auth-container-support
052db54c80a71e8e596a46f701c624abc94c1ea1	refs/heads/main ✅
- On branch fix/git-auth-container-support
Your branch is up to date with 'origin/fix/git-auth-container-support'.

nothing to commit, working tree clean ✅  
-  ✅ (with auto-upstream)
- Subsequent pushes ✅

Gateway logs confirm 200 responses for git operations.

Closes #2