### PR TITLE
fix: hide .env secrets from agent container via /dev/null bind mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     tty: true              # -t
     volumes:
       - .:/workspace
+      - /dev/null:/workspace/.env:ro          # Hide real secrets from agent
+      - /dev/null:/workspace/.env.example:ro  # Hide template too
       - pi-data:/home/pi/.pi/agent
     env_file:
       - path: .env.agent

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,12 @@ if [ -n "$HTTPS_PROXY" ]; then
     echo "Gateway CA certificate installed."
 fi
 
+# ── Security: verify real secrets aren't leaked into workspace ────
+if [ -f /workspace/.env ] && grep -qE 'sk-ant-ort01-|BSAp-|gho_' /workspace/.env 2>/dev/null; then
+    echo "⚠️  WARNING: Real secrets detected in /workspace/.env!" >&2
+    echo "   Container may be misconfigured. Check volume mounts." >&2
+fi
+
 # ── Skills sync ──────────────────────────────────────────────────
 # Sync baked-in skills from the image staging area into the persistent volume.
 # This ensures rebuilds with updated skills take effect without wiping sessions.


### PR DESCRIPTION
## Summary

Bind-mount `/dev/null` (read-only) over `.env` and `.env.example` in the agent container's workspace, preventing the agent from reading real API credentials that leak through the workspace bind mount.

Also adds a defense-in-depth safety check in `entrypoint.sh` that warns if real secret patterns are detected in `/workspace/.env` at startup.

## Changes

- **`docker-compose.yml`** — Added `/dev/null:/workspace/.env:ro` and `/dev/null:/workspace/.env.example:ro` overlay mounts
- **`entrypoint.sh`** — Added runtime safety check for leaked secret patterns

## Testing

| Test | Result |
|------|--------|
| `cat /workspace/.env` | Empty output (reads `/dev/null`) |
| `ls -la /workspace/.env` | Shows `crw-rw-rw-` char device, not a regular file |
| Agent dummy credentials | ✅ Loaded from `.env.agent` as expected |
| Gateway real credentials | ✅ Still has real tokens via `env_file: .env` |
| `grep` for real secret patterns | Not found in `/workspace/.env` |
| Entrypoint safety check | Silent (no warning — secrets properly hidden) |

## Notes

The issue originally proposed anonymous volume overlays (`- /workspace/.env`), but that fails at runtime because Docker volumes are directories and can't overlay a file. The `/dev/null` bind mount is cleaner — `.env` appears as an empty character device.

Closes #5